### PR TITLE
Add main Wiki page link to keep the README.md short & clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Box built with macOS 12.1. By using this vagrant box, you must respect the [soft
     ProductVersion: 12.1
     BuildVersion:   21C52
 
+
+[Please see the Wiki for usage information and FAQs.][1]
+
+[1]: https://github.com/LyraPhase/vagrant-macos-monterey-12-1-base/wiki


### PR DESCRIPTION
… because it's packaged with private Vagrant `.box` file